### PR TITLE
Update vue-credit-card-validation.js

### DIFF
--- a/dist/vue-credit-card-validation.js
+++ b/dist/vue-credit-card-validation.js
@@ -705,7 +705,7 @@ var VueCardFormat = {
     vue.directive('cardformat', {
       bind: function bind(el, binding, vnode) {
         // see if el is an input
-        if (el.nodeName !== 'input'){
+        if (el.nodeName.toLowerCase() !== 'input'){
           el = el.querySelector('input');
         }
         // call format function from prop


### PR DESCRIPTION
I have found that because the nodeName string in Chrome is "INPUT", it breaks the functionality and an error is logged to console:

TypeError: Cannot read property 'addEventListener' of null

So, I thought that just adding toLowerCase() should fix the issue.