### PR TITLE
Fix Cannot read property 'addEventListener' of null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const VueCardFormat = {
     vue.directive('cardformat', {
       bind(el, binding, vnode) {
         // see if el is an input
-        if (el.nodeName !== 'input'){
+        if (el.nodeName.toLowerCase() !== 'input'){
           el = el.querySelector('input');
         }
         // call format function from prop


### PR DESCRIPTION
The value of el.nodeName in Chrome is INPUT in capital letters, should be fixed with adding toLowerCase()

