### PR TITLE
Accept 16 digit long AMEX cards

### DIFF
--- a/src/cards.js
+++ b/src/cards.js
@@ -49,7 +49,7 @@ export default [
         type: 'amex',
         patterns: [34, 37],
         format: /(\d{1,4})(\d{1,6})?(\d{1,5})?/,
-        length: [15],
+        length: [15,16],
         cvcLength: [3, 4],
         luhn: true
     },


### PR DESCRIPTION
AMEX cards can also be 16 digits long, eg. 3455555555555504 would be a valid credit card number

